### PR TITLE
Fix Style CI configuration

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/tests/GitterChannelTest.php
+++ b/tests/GitterChannelTest.php
@@ -6,8 +6,8 @@ use Mockery;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Notifications\Notification;
-use NotificationChannels\Gitter\GitterMessage;
 use NotificationChannels\Gitter\GitterChannel;
+use NotificationChannels\Gitter\GitterMessage;
 use NotificationChannels\Gitter\Exceptions\CouldNotSendNotification;
 
 class GitterChannelTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
This removes the deprecated Style CI `linting` flag, and applies the required formatting changes.